### PR TITLE
release 20200406

### DIFF
--- a/latest.json
+++ b/latest.json
@@ -1,13 +1,13 @@
 {
   "version": "11.0",
   "datetime": 1617657793,
-  "release": "20200405",
-  "minimum_stack_version": "11.0.7",
+  "release": "20200406",
+  "minimum_stack_version": "11.0.10",
   "chromium": "89.0.4389.105",
   "revisions": {
     "android-prepare-vendor": "4e3aea63bd5b16b409cce34538b218b186654f5e",
     "platform_packages_apps_Updater": "9ae81050aa8401da67dbeac7ecfd9ff1c677fad7",
-    "platform_prebuilts_chromium": "014bfe0637c16e8ce19a645c632f814c5fbbc568",
+    "platform_prebuilts_chromium": "dea7974bb091e9f000992583b4edb29a6269d908",
     "platform_prebuilts_fdroid": "a65b3f069e20b01c2d61e1a7b69df9c020b5108b",
     "privileged-extension": "b1af615fde5d9da668e7843c272a3a28eaf863f5"
   },


### PR DESCRIPTION
* this release is to fix issue with chromium browser not showing up as app in 20200405
* bump commit of platform_prebuilts_chromium to pick up static chromium build args
* bump required version of stack to 11.0.10